### PR TITLE
1.7 - Crash Fix

### DIFF
--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/AttackInstance.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/AttackInstance.java
@@ -103,7 +103,7 @@ public abstract class AttackInstance implements Runnable {
 
     protected void end() {
         List<MoveTemplate> moveTemplates = pokemonEntity.getPokemon().getMoveSet().getMoves().stream().map(it -> it.getTemplate()).toList();
-        boolean hasTeleport = moveTemplates.contains(Moves.INSTANCE.getByName("teleport"));
+        boolean hasTeleport = moveTemplates.contains(Moves.getByName("teleport"));
 
         if (hasTeleport) {
             pokemonEntity.randomTeleport(8, 4, 8, true);

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/BugAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/BugAttack.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class BugAttack extends PokeAttack {
 
     public BugAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getBUG(), isRanged);
+        super(api, ElementalTypes.BUG, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/DarkAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/DarkAttack.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
 public class DarkAttack extends PokeAttack {
 
     public DarkAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getDARK(), isRanged);
+        super(api, ElementalTypes.DARK, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/DragonAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/DragonAttack.java
@@ -29,7 +29,7 @@ public class DragonAttack extends PokeAttack {
     public static Map<DragonFireball, FireAttack.FireballAttackData> fireballsLaunched = new HashMap<>();
 
     public DragonAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getDRAGON(), isRanged);
+        super(api, ElementalTypes.DRAGON, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/ElectricAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/ElectricAttack.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class ElectricAttack extends PokeAttack {
 
     public ElectricAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getELECTRIC(), isRanged);
+        super(api, ElementalTypes.ELECTRIC, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FairyAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FairyAttack.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class FairyAttack extends PokeAttack {
 
     public FairyAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getFAIRY(), isRanged);
+        super(api, ElementalTypes.FAIRY, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FightingAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FightingAttack.java
@@ -16,7 +16,7 @@ import java.util.concurrent.CompletableFuture;
 public class FightingAttack extends PokeAttack {
 
     public FightingAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getFIGHTING(), isRanged);
+        super(api, ElementalTypes.FIGHTING, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FireAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FireAttack.java
@@ -26,7 +26,7 @@ public class FireAttack extends PokeAttack {
     public static Map<SmallFireball, FireballAttackData> fireballsLaunched = new HashMap<>();
 
     public FireAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getFIRE(), isRanged);
+        super(api, ElementalTypes.FIRE, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FlyingAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/FlyingAttack.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class FlyingAttack extends PokeAttack {
 
     public FlyingAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getFLYING(), isRanged);
+        super(api, ElementalTypes.FLYING, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/GhostAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/GhostAttack.java
@@ -26,7 +26,7 @@ public class GhostAttack extends PokeAttack {
     public static List<UUID> EVOKER_FANGS = new ArrayList<>();
 
     public GhostAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getGHOST(), isRanged);
+        super(api, ElementalTypes.GHOST, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/GrassAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/GrassAttack.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class GrassAttack extends PokeAttack {
 
     public GrassAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getGRASS(), isRanged);
+        super(api, ElementalTypes.GRASS, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/GroundAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/GroundAttack.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
 public class GroundAttack extends PokeAttack {
 
     public GroundAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getGROUND(), isRanged);
+        super(api, ElementalTypes.GROUND, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/IceAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/IceAttack.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 public class IceAttack extends PokeAttack {
 
     public IceAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getICE(), isRanged);
+        super(api, ElementalTypes.ICE, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/NormalAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/NormalAttack.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
 public class NormalAttack extends PokeAttack {
 
     public NormalAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getNORMAL(), isRanged);
+        super(api, ElementalTypes.NORMAL, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/PoisonAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/PoisonAttack.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class PoisonAttack extends PokeAttack {
 
     public PoisonAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getPOISON(), isRanged);
+        super(api, ElementalTypes.POISON, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/PsychicAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/PsychicAttack.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 public class PsychicAttack extends PokeAttack {
 
     public PsychicAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getPSYCHIC(), isRanged);
+        super(api, ElementalTypes.PSYCHIC, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/RockAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/RockAttack.java
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletableFuture;
 public class RockAttack extends PokeAttack {
 
     public RockAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getROCK(), isRanged);
+        super(api, ElementalTypes.ROCK, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/SteelAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/SteelAttack.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 public class SteelAttack extends PokeAttack {
 
     public SteelAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getSTEEL(), isRanged);
+        super(api, ElementalTypes.STEEL, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/WaterAttack.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/attacks/types/WaterAttack.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
 public class WaterAttack extends PokeAttack {
 
     public WaterAttack(FOFApi api, boolean isRanged) {
-        super(api, ElementalTypes.INSTANCE.getWATER(), isRanged);
+        super(api, ElementalTypes.WATER, isRanged);
     }
 
     @Override

--- a/src/main/java/com/github/kuramastone/fightOrFlight/mixins/DragonFireballMixin.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/mixins/DragonFireballMixin.java
@@ -45,10 +45,10 @@ public class DragonFireballMixin {
             Entity defender = null;
             if (hitResult.getType() == HitResult.Type.ENTITY) {
                 defender = ((EntityHitResult) hitResult).getEntity();
-                PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.INSTANCE.getDRAGON(), data.pokemonEntity, data.targetEntity);
+                PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.DRAGON, data.pokemonEntity, data.targetEntity);
             }
             else if (hitResult.getType() == HitResult.Type.BLOCK) {
-                PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.INSTANCE.getDRAGON(), data.pokemonEntity, data.targetEntity);
+                PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.DRAGON, data.pokemonEntity, data.targetEntity);
             }
 
             //spawn effects

--- a/src/main/java/com/github/kuramastone/fightOrFlight/mixins/LivingEntityMixin.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/mixins/LivingEntityMixin.java
@@ -47,7 +47,7 @@ public class LivingEntityMixin {
 
                         // replace damage with the equivalent damage of a 50bp move
                         Pokemon pokeAttacker = FightOrFlightMod.instance.getAPI().getConfigOptions().getPokemonEquivalent(livingAttacker.getType());
-                        float pokeDamage = (float) PokeUtils.calculatePokeAttackDamage(pokeAttacker, pokeDefender.getPokemon(), ElementalTypes.INSTANCE.getNORMAL(), 50, false, true);
+                        float pokeDamage = (float) PokeUtils.calculatePokeAttackDamage(pokeAttacker, pokeDefender.getPokemon(), ElementalTypes.NORMAL, 50, false, true);
                         float entityDamage = pokeDamage / pokeDefender.getPokemon().getMaxHealth() * pokeDefender.getMaxHealth();
                         f = entityDamage;
 

--- a/src/main/java/com/github/kuramastone/fightOrFlight/mixins/SmallFireballMixin.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/mixins/SmallFireballMixin.java
@@ -34,7 +34,7 @@ public class SmallFireballMixin {
             Entity defender = entityHitResult.getEntity();
             SmallFireball fireball = (SmallFireball) (Object) this;
             if (defender instanceof LivingEntity) {
-                PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.INSTANCE.getFIRE(), data.pokemonEntity, data.targetEntity);
+                PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.FIRE, data.pokemonEntity, data.targetEntity);
             }
 
             dataMap.remove(this);
@@ -53,7 +53,7 @@ public class SmallFireballMixin {
         if (dataMap.containsKey(this)) {
 
             FireAttack.FireballAttackData data = dataMap.get(this);
-            PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.INSTANCE.getFIRE(), data.pokemonEntity, data.targetEntity);
+            PokeAttack.calculateDamage(1.0 / data.fireballsSent, data.isSpecial, ElementalTypes.FIRE, data.pokemonEntity, data.targetEntity);
             ci.cancel();
         }
     }

--- a/src/main/java/com/github/kuramastone/fightOrFlight/utils/FleeUtils.java
+++ b/src/main/java/com/github/kuramastone/fightOrFlight/utils/FleeUtils.java
@@ -13,13 +13,13 @@ public class FleeUtils {
     public static int getAbilityFleeScore(Pokemon pokemon) {
         AbilityTemplate ability = pokemon.getAbility().getTemplate();
 
-        if (ability == Abilities.INSTANCE.get("intimidate")) {
+        if (ability == Abilities.get("intimidate")) {
             return -1;
         }
-        if (ability == Abilities.INSTANCE.get("defiant")) {
+        if (ability == Abilities.get("defiant")) {
             return -1;
         }
-        if (ability == Abilities.INSTANCE.get("run_away")) {
+        if (ability == Abilities.get("run_away")) {
             return 2;
         }
 


### PR DESCRIPTION
# 1.7 - Crash Fix

## Description
- Due to the recent Cobblemon changes, there were some new issues that caused crashes, namely the use of `INSTANCE`.

## Changes
- Updated ability checks to avoid using `Abilities.INSTANCE.get()` which is no longer valid.
  - Use `Abilities.get()` 
- Updated move checks to avoid using `Moves.INSTANCE.getByName()` which is no longer valid.
  - Use `Moves.getByName()`
- Updated `ElementalTypes.INSTANCE.get<TYPE>` which is deprecated.
  - Use `ElementalTypes.<TYPE>` constant. 